### PR TITLE
Security: Don't call handler until CSRF token has been validated

### DIFF
--- a/src/guard.rs
+++ b/src/guard.rs
@@ -67,8 +67,6 @@ where
         let future = self.inner.call(request);
 
         Box::pin(async move {
-            let response = future.await?;
-
             let config = match config.ok_or(Error::ExtensionNotFound("Config".into())) {
                 Ok(config) => config,
                 Err(err) => return Error::make_layer_error(err),
@@ -95,6 +93,8 @@ where
             match validate_token(&config.secret, &cookie_value, &header_value) {
                 Ok(valid) => {
                     if valid {
+                        let response = future.await?;
+
                         Ok(response)
                     } else {
                         Error::make_layer_forbidden()


### PR DESCRIPTION
Fixes #13. I haven't checked for other security issues. 

I would consider releasing a new version, issuing a rust security advisory, and revoking old releases. 